### PR TITLE
自動デプロイ時にdockerの操作を止める

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,6 @@ jobs:
       - run:
           name: Reflect Code
           command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && sudo git pull origin main'
-      - run:
-          name: Docker Run
-          command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose build && docker-compose up'
 
 workflows:
   version: 2


### PR DESCRIPTION
``docker-compose up``が自動デプロイの際に、完了通知をcircleCIに送信していなかった
よって、circleCIがエラーとなっていた。
他の対策方法が出てくるまでは、dockerのコマンド実行は手動でやることにしたため、RUNを消去した。