### PR TITLE
REDISの接続エラーを修正する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 .env
+
+/data/redis/*

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,3 @@
 require 'redis-rails'
 
-REDIS = Redis.new(host: ENV['REDIS_HOST'], port: ENV['REDIS_PORT'])
+REDIS = Redis.new(host: "redis", port: 6379, db: 0)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,3 @@
 require 'redis-rails'
 
-REDIS = Redis.new(host: "redis", port: 6379, db: 0)
+REDIS = Redis.new(host: ENV['REDIS_HOST'], port: ENV['REDIS_PORT'],db: ENV['REDIS_DB'])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - 6379:6379
     volumes:
-      - ./data/redis:/data
+      - ./log:/var/log/redis
     command: redis-server --appendonly yes
     networks:
       - saving-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - 6379:6379
     volumes:
       - ./log:/var/log/redis
+      - ./data/redis:/data
     command: redis-server --appendonly yes
     networks:
       - saving-network


### PR DESCRIPTION
REDISの接続エラーが起こっていたので、修正した。
#8 で環境変数でREDISの環境を指定しようとした際に、dbの設定が抜けていたのが原因
サーバー側で.envにREDIS_DBを追加し、それを初期化時に読ませるようにした。
今後の保守性も考え、redisのログをdockerコンテナに記録するようにもした。