### PR TITLE
docker-compose upにバックグラウンド実行のオプションをつける

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,12 @@ jobs:
       - run:
           name: Reflect Code
           command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && sudo git pull origin main'
+      - run:
+          name: Docker task
+          command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose build && docker-compose up -b'
+      - run:
+          name: database setup
+          command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose run app rails db:migrate'
 
 workflows:
   version: 2


### PR DESCRIPTION
自動デプロイでコンテナを起動する際に、コマンドが終了しないことにより、circleCIでエラーが返ってきていた。
docker-compose up に-bオプションを付与することにより、解決した。
