### PR TITLE
circleCIのジョブ変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && sudo git pull origin main'
       - run:
           name: Docker task
-          command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose build && docker-compose up -d'
+          command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose down && docker-compose build --no-cache && docker-compose up -d'
       - run:
           name: database setup
           command: ssh ${USER_NAME}@${HOST_NAME} 'cd /saving && docker-compose exec -T app rails db:migrate RAILS_ENV=production'


### PR DESCRIPTION
circleCIでのdocker実行時にコンテナを一時的にdownさせ、コンテナイメージの作成時にキャッシュを使わないようにした。
（dockerイメージ作成時にキャッシュを使用することがあり、コンテナにgit pullしたコードが反映されないことがあったため）