### PR TITLE
セッション作成時のエラーレスポンスも仕様に合わせる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 !/log/.keep
 !/tmp/.keep
 
+/data/*
+
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*
 !/tmp/pids/
@@ -37,5 +39,3 @@ config/environments/*.local.yml
 .env
 
 .idea
-
-/data/redis/*

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::API
   end
 
   def record_not_found
-    render json: {error:{code:Settings.error_codes.record_not_found,message: "record not found"}}
+    render json: {code:Settings.error_codes.record_not_found,message: "record not found"},status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,8 @@ class UsersController < ApplicationController
           attribute, error_key, error_info.except(*ActiveModel::Callbacks),
           )
 
-        error = {
+        error =
+          {
             code: Settings.error_codes.models.send(class_name)&.send(attribute)&.send(error_key) ||
               Settings.error_codes.unprocessable_entity, # error_codesにて定義のないエラーの場合、汎用的なエラーコードを返す
             message: active_model_errors.full_message(attribute, message),

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,8 +26,12 @@ class UsersController < ApplicationController
           attribute, error_key, error_info.except(*ActiveModel::Callbacks),
           )
 
+<<<<<<< Updated upstream
         error =
           {
+=======
+        error = {
+>>>>>>> Stashed changes
             code: Settings.error_codes.models.send(class_name)&.send(attribute)&.send(error_key) ||
               Settings.error_codes.unprocessable_entity, # error_codesにて定義のないエラーの場合、汎用的なエラーコードを返す
             message: active_model_errors.full_message(attribute, message),

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,12 +26,7 @@ class UsersController < ApplicationController
           attribute, error_key, error_info.except(*ActiveModel::Callbacks),
           )
 
-<<<<<<< Updated upstream
-        error =
-          {
-=======
         error = {
->>>>>>> Stashed changes
             code: Settings.error_codes.models.send(class_name)&.send(attribute)&.send(error_key) ||
               Settings.error_codes.unprocessable_entity, # error_codesにて定義のないエラーの場合、汎用的なエラーコードを返す
             message: active_model_errors.full_message(attribute, message),


### PR DESCRIPTION
セッション作成時のエラーレスポンスが仕様変更前のものになっていたため、修正した。
また、redisのデータをgit管理しないようにもした