### PR TITLE
patiencesテーブルのregistered_atカラムのデータ型をdataからdatetimeに変更

### DIFF
--- a/db/migrate/20210826085333_change_data_registered_at_to_patience.rb
+++ b/db/migrate/20210826085333_change_data_registered_at_to_patience.rb
@@ -1,0 +1,5 @@
+class ChangeDataRegisteredAtToPatience < ActiveRecord::Migration[6.1]
+  def change
+      change_column :patiences, :registered_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_20_033946) do
+ActiveRecord::Schema.define(version: 2021_08_26_085333) do
 
   create_table "patiences", charset: "utf8", force: :cascade do |t|
     t.integer "money"
     t.bigint "user_id", null: false
     t.string "memo"
     t.string "category_title", null: false
-    t.date "registered_at", null: false
+    t.datetime "registered_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "registered_at"], name: "index_patiences_on_user_id_and_registered_at"


### PR DESCRIPTION
クライアント側でUTC時間と日本時間を考慮し、APIに送ることをしていたが、単にバックエンド側でpatiencesテーブルのregistered_atカラムのデータ型をdataからdatetimeに変更すればいいというだけだったのでそのようにした