### PR TITLE
データをフェッチする際の日付のパラメーターについて通常の日付を受け取れるようにする

### DIFF
--- a/app/controllers/patiences_controller.rb
+++ b/app/controllers/patiences_controller.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'date'
 
 class PatiencesController < ApplicationController
   def create
@@ -36,8 +37,8 @@ class PatiencesController < ApplicationController
   end
 
   def per_month
-    begin_month = params[:date].begin_of_month
-    end_month = params[:date].end_of_month
+    begin_month = Date.parse(params[:date]).beginning_of_month
+    end_month = Date.parse(params[:date]).end_of_month
     patiences = Session.current_user.patiences.where(registered_at:begin_month..end_month)
     status = :ok
     render json:{patiences:patiences},status:status

--- a/app/controllers/patiences_controller.rb
+++ b/app/controllers/patiences_controller.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 class PatiencesController < ApplicationController
   def create
     user = Session.current_user
@@ -34,13 +36,16 @@ class PatiencesController < ApplicationController
   end
 
   def per_month
-    patiences = Session.current_user.patiences.where(registered_at:params[:start_date]..params[:end_date])
+    begin_month = params[:date].begin_of_month
+    end_month = params[:date].end_of_month
+    patiences = Session.current_user.patiences.where(registered_at:begin_month..end_month)
     status = :ok
     render json:{patiences:patiences},status:status
   end
 
   def per_day
-    patiences = Session.current_user.patiences.where(registered_at:params[:date])
+    date = Time.parse(params[:date]).localtime.to_date.to_time
+    patiences = Session.current_user.patiences.where(registered_at:date)
     status = :ok
     render json:{patiences:patiences},status:status
   end


### PR DESCRIPTION
今までクライアント側で日付パラメーターを渡すときは0時に合わせたり、月初と月終を指定するようにしていたが、バグになりやすそうだったのでバックエンド側で日付の操作を行うようにした