### PR TITLE
登録日のデータ型をDateTimeからDateに変更

### DIFF
--- a/app/controllers/patiences_controller.rb
+++ b/app/controllers/patiences_controller.rb
@@ -39,16 +39,13 @@ class PatiencesController < ApplicationController
   def per_month
     begin_month = params[:date].in_time_zone.beginning_of_month
     end_month = params[:date].in_time_zone.end_of_month
-    logger.info "begin_month: #{begin_month}"
-    logger.info "end_month: #{end_month}"
     patiences = Session.current_user.patiences.where(registered_at:begin_month..end_month)
     status = :ok
     render json:{patiences:patiences},status:status
   end
 
   def per_day
-    date = Time.parse(params[:date]).in_time_zone
-    logger.info "date: #{date}"
+    date = Time.parse(params[:date]).in_time_zone.to_date
     patiences = Session.current_user.patiences.where(registered_at:date)
     status = :ok
     render json:{patiences:patiences},status:status

--- a/app/controllers/patiences_controller.rb
+++ b/app/controllers/patiences_controller.rb
@@ -5,7 +5,9 @@ class PatiencesController < ApplicationController
   def create
     user = Session.current_user
     patience = user.patiences.build(patience_params)
-    status = :bad_request
+    date = params[:registered_at].in_time_zone.to_date
+    patience.registered_at = date
+
     if patience.save
       status = :ok
       render json:{message:"patience has been registered",id:patience.id,money:patience.money,

--- a/db/migrate/20210906074745_change_data_registered_at_to_patiences.rb
+++ b/db/migrate/20210906074745_change_data_registered_at_to_patiences.rb
@@ -1,0 +1,5 @@
+class ChangeDataRegisteredAtToPatiences < ActiveRecord::Migration[6.1]
+  def change
+    change_column :patiences, :registered_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_26_085333) do
+ActiveRecord::Schema.define(version: 2021_09_06_074745) do
 
   create_table "patiences", charset: "utf8", force: :cascade do |t|
     t.integer "money"
     t.bigint "user_id", null: false
     t.string "memo"
     t.string "category_title", null: false
-    t.datetime "registered_at", null: false
+    t.date "registered_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "registered_at"], name: "index_patiences_on_user_id_and_registered_at"


### PR DESCRIPTION
登録日(`registered_at`)はそのデータの性質上時間の管理までは不要だったので、日付のみを扱うDate型に変換した