### PR TITLE
dateを新しく作り直しているので、更新の際は、ストロングパラメーターを使用せずに、一つ一つ代入するようにする

### DIFF
--- a/app/controllers/patiences_controller.rb
+++ b/app/controllers/patiences_controller.rb
@@ -20,11 +20,8 @@ class PatiencesController < ApplicationController
   def update
     patience = Session.current_user.patiences.find_by(id:params[:id])
     date = params[:registered_at].in_time_zone.to_date
-    logger.info("date #{date}")
-    patience.registered_at = date
-    logger.info("registere_date #{patience.registered_at}")
     status = :bad_request
-    if patience.update(patience_params)
+    if patience.update(category_title: patience.category_title,memo: patience.memo,money: patience.money,registered_at: date)
       status = :ok
       render json:{message:"patience has been updated",id:patience.id,money:patience.money,
                    memo:patience.memo,category_title:patience.category_title,registered_at:patience.registered_at},status:status
@@ -53,7 +50,6 @@ class PatiencesController < ApplicationController
   def per_day
     date = Time.parse(params[:date]).in_time_zone.to_date
     patiences = Session.current_user.patiences.where(registered_at:date)
-    logger.info("per_day #{date}")
     status = :ok
     render json:{patiences:patiences},status:status
   end


### PR DESCRIPTION
dateが更新されない不具合があった。

dateを新しく作り直しているので、更新の際は、ストロングパラメーターを使用せずに、一つ一つ代入するようにする。